### PR TITLE
Add match score recording

### DIFF
--- a/app/Http/Controllers/CompetitionController.php
+++ b/app/Http/Controllers/CompetitionController.php
@@ -54,6 +54,7 @@ class CompetitionController extends Controller
 
         return view('competitions.show', [
             'competition' => $competition,
+            'stages'      => $competition->stages,
             'entries'     => $entries,
             'standings'   => $standings,
         ]);

--- a/app/Http/Controllers/MatchResultController.php
+++ b/app/Http/Controllers/MatchResultController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\MatchResultRequest;
+use App\Models\Competition;
+use App\Models\MatchResult;
+use App\Models\Stage;
+use App\Services\EntryService;
+use App\Services\MatchResultService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class MatchResultController extends Controller
+{
+    public function __construct(
+        protected EntryService       $entryService,
+        protected MatchResultService $matchResultService,
+    ) {}
+
+    public function index(Competition $competition, Stage $stage): View
+    {
+        $matches = $this->matchResultService->getMatchResultsForStage($stage);
+
+        return view('matches.index', [
+            'competition' => $competition,
+            'stage'       => $stage,
+            'matches'     => $matches,
+        ]);
+    }
+
+    public function create(Competition $competition, Stage $stage): View
+    {
+        $entries = $this->entryService->getCompetitionEntries($competition);
+
+        return view('matches.create', [
+            'competition' => $competition,
+            'stage'       => $stage,
+            'entries'     => $entries,
+        ]);
+    }
+
+    public function store(MatchResultRequest $request, Competition $competition, Stage $stage): RedirectResponse
+    {
+        $data = $request->validated();
+        $this->matchResultService->recordMatchResult($stage, $data);
+
+        return redirect()->route('competitions.show', $competition);
+    }
+
+    public function show(Competition $competition, Stage $stage, MatchResult $match): View
+    {
+        return view('matches.show', [
+            'competition' => $competition,
+            'stage'       => $stage,
+            'match'       => $match,
+        ]);
+    }
+
+    public function edit(Competition $competition, Stage $stage, MatchResult $match): View
+    {
+        $entries = $this->entryService->getCompetitionEntries($competition);
+
+        return view('matches.edit', [
+            'competition' => $competition,
+            'stage'       => $stage,
+            'entries'     => $entries,
+            'match'       => $match,
+        ]);
+    }
+
+    public function update(MatchResultRequest $request, Competition $competition, Stage $stage, MatchResult $match): RedirectResponse
+    {
+        $data = $request->validated();
+        $this->matchResultService->updateMatchResult($match, $stage, $data);
+
+        return redirect()->route('competitions.show', $competition);
+    }
+
+    public function destroy(Competition $competition, Stage $stage, MatchResult $match): RedirectResponse
+    {
+        $this->matchResultService->removeMatchResult($match);
+
+        return redirect()->route('competitions.show', $competition);
+    }
+}

--- a/app/Http/Requests/MatchRequest.php
+++ b/app/Http/Requests/MatchRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MatchRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'shot_at'                  => ['required', 'date'],
+            'stage_id'                 => ['required', 'exists:stages,id'],
+            'left_score'               => ['required', 'array:entry_id,match_points'],
+            'left_score.entry_id'      => ['required', 'exists:entries,id'],
+            'left_score.match_points'  => ['required', 'integer', 'min:0', 'max:150'],
+            'right_score'              => ['required', 'array:entry_id,match_points'],
+            'right_score.entry_id'     => ['required', 'exists:entries,id'],
+            'right_score.match_points' => ['required', 'integer', 'min:0', 'max:150'],
+        ];
+    }
+}

--- a/app/Http/Requests/MatchResultRequest.php
+++ b/app/Http/Requests/MatchResultRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class MatchRequest extends FormRequest
+class MatchResultRequest extends FormRequest
 {
     public function rules(): array
     {
@@ -15,7 +15,7 @@ class MatchRequest extends FormRequest
             'left_score.entry_id'      => ['required', 'exists:entries,id'],
             'left_score.match_points'  => ['required', 'integer', 'min:0', 'max:150'],
             'right_score'              => ['required', 'array:entry_id,match_points'],
-            'right_score.entry_id'     => ['required', 'exists:entries,id'],
+            'right_score.entry_id'     => ['required', 'exists:entries,id', 'different:left_score.entry_id'],
             'right_score.match_points' => ['required', 'integer', 'min:0', 'max:150'],
         ];
     }

--- a/app/Http/Requests/MatchResultRequest.php
+++ b/app/Http/Requests/MatchResultRequest.php
@@ -10,7 +10,6 @@ class MatchResultRequest extends FormRequest
     {
         return [
             'shot_at'                  => ['required', 'date'],
-            'stage_id'                 => ['required', 'exists:stages,id'],
             'left_score'               => ['required', 'array:entry_id,match_points'],
             'left_score.entry_id'      => ['required', 'exists:entries,id'],
             'left_score.match_points'  => ['required', 'integer', 'min:0', 'max:150'],

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -32,14 +32,19 @@ class Entry extends Model
 
     // Relationships ----
 
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
     public function competition(): BelongsTo
     {
         return $this->belongsTo(Competition::class);
     }
 
-    public function person(): BelongsTo
+    public function scores(): HasMany
     {
-        return $this->belongsTo(Person::class);
+        return $this->hasMany(Score::class);
     }
 
     public function standings(): HasMany

--- a/app/Models/MatchResult.php
+++ b/app/Models/MatchResult.php
@@ -67,6 +67,16 @@ class MatchResult extends Model
     // Scopes ----
 
     /** @noinspection PhpUnused */
+    public function scopeInCompetition(Builder $query, Competition $competition): Builder
+    {
+        return $query->whereHas('round', fn(Builder|Round $round) => $round
+            ->whereHas('stage', fn(Builder|Stage $stage) => $stage
+                ->whereCompetitionId($competition->id)
+            )
+        );
+    }
+
+    /** @noinspection PhpUnused */
     public function scopeInStage(Builder $query, Stage $stage): Builder
     {
         return $query->whereHas('round', fn(Builder|Round $round) => $round->whereStageId($stage->id));

--- a/app/Models/MatchResult.php
+++ b/app/Models/MatchResult.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class MatchResult extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'round_id',
+        'left_score_id',
+        'right_score_id',
+        'winner_id',
+        'shot_at',
+    ];
+
+    protected $casts = [
+        'round_id'       => 'integer',
+        'left_score_id'  => 'integer',
+        'right_score_id' => 'integer',
+        'winner_id'      => 'integer',
+        'shot_at'        => 'immutable_datetime',
+    ];
+
+    // Attributes ----
+
+    public function hasWinner(): Attribute
+    {
+        return Attribute::get(fn() => !!$this->winner_id);
+    }
+
+    public function isDraw(): Attribute
+    {
+        return Attribute::get(fn() => !$this->winner_id);
+    }
+
+    // Relationships ----
+
+    public function round(): BelongsTo
+    {
+        return $this->belongsTo(Round::class);
+    }
+
+    public function leftScore(): BelongsTo
+    {
+        return $this->belongsTo(Score::class, 'left_score_id');
+    }
+
+    public function rightScore(): BelongsTo
+    {
+        return $this->belongsTo(Score::class, 'right_score_id');
+    }
+
+    public function winner(): BelongsTo
+    {
+        return $this->belongsTo(Entry::class, 'winner_id');
+    }
+
+    // Scopes ----
+
+    /** @noinspection PhpUnused */
+    public function scopeShotBefore(Builder $query, CarbonInterface $dateTime): Builder
+    {
+        return $query->where('shot_at', '<', $dateTime);
+    }
+}

--- a/app/Models/MatchResult.php
+++ b/app/Models/MatchResult.php
@@ -67,8 +67,48 @@ class MatchResult extends Model
     // Scopes ----
 
     /** @noinspection PhpUnused */
+    public function scopeInStage(Builder $query, Stage $stage): Builder
+    {
+        return $query->whereHas('round', fn(Builder|Round $round) => $round->whereStageId($stage->id));
+    }
+
+    /** @noinspection PhpUnused */
+    public function scopeInRound(Builder $query, Round $round): Builder
+    {
+        return $query->where('round_id', $round->id);
+    }
+
+    /** @noinspection PhpUnused */
     public function scopeShotBefore(Builder $query, CarbonInterface $dateTime): Builder
     {
         return $query->where('shot_at', '<', $dateTime);
+    }
+
+    /** @noinspection PhpUnused */
+    public function scopeShotBy(Builder $query, Entry $entry): Builder
+    {
+        return $query->where(fn(Builder|self $match) => $match
+            ->whereHas('leftScore', fn(Builder|Score $score) => $score
+                ->where('entry_id', $entry->id)
+            )
+            ->orWhereHas('rightScore', fn(Builder|Score $score) => $score
+                ->where('entry_id', $entry->id)
+            )
+        );
+    }
+
+    /** @noinspection PhpUnused */
+    public function scopeShotByBoth(Builder $query, Entry $firstEntry, Entry $secondEntry): Builder
+    {
+        return $query->where(fn(Builder|self $match) => $match
+            ->whereHas('leftScore', fn(Builder|Score $score) => $score
+                ->where('entry_id', $firstEntry->id)
+                ->orWhere('entry_id', $secondEntry->id)
+            )
+            ->whereHas('rightScore', fn(Builder|Score $score) => $score
+                ->where('entry_id', $firstEntry->id)
+                ->orWhere('entry_id', $secondEntry->id)
+            )
+        );
     }
 }

--- a/app/Models/Score.php
+++ b/app/Models/Score.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Score extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'entry_id',
+        'handicap_before',
+        'handicap_after',
+        'allowance',
+        'match_points',
+        'match_points_adjusted',
+        'bonus_points',
+        'league_points',
+    ];
+
+    protected $casts = [
+        'entry_id'              => 'integer',
+        'handicap_before'       => 'integer',
+        'handicap_after'        => 'integer',
+        'allowance'             => 'integer',
+        'match_points'          => 'integer',
+        'match_points_adjusted' => 'integer',
+        'bonus_points'          => 'integer',
+        'league_points'         => 'integer',
+    ];
+
+    // Relationships ----
+
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(Entry::class);
+    }
+
+    public function matchResult(): HasOne
+    {
+        return $this->hasOne(MatchResult::class);
+    }
+}

--- a/app/Models/Stage.php
+++ b/app/Models/Stage.php
@@ -55,7 +55,7 @@ class Stage extends Model
     public function standings(): HasMany
     {
         return $this->hasMany(Standing::class)
-            ->orderByDesc('league_points')
+            ->orderByDesc('total_points')
             ->orderByDesc('bonus_points')
             ->orderByDesc('matches_won')
             ->orderByDesc('match_points_adjusted')

--- a/app/Models/Standing.php
+++ b/app/Models/Standing.php
@@ -22,6 +22,7 @@ class Standing extends Model
         'match_points_adjusted',
         'bonus_points',
         'league_points',
+        'total_points',
     ];
 
     protected $casts = [
@@ -35,6 +36,7 @@ class Standing extends Model
         'match_points_adjusted' => 'integer',
         'bonus_points'          => 'integer',
         'league_points'         => 'integer',
+        'total_points'          => 'integer',
     ];
 
     // Relationships ----

--- a/app/Policies/MatchPolicy.php
+++ b/app/Policies/MatchPolicy.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\MatchResult;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class MatchPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, MatchResult $match): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, MatchResult $match): bool
+    {
+        return true;
+    }
+
+    public function delete(User $user, MatchResult $match): bool
+    {
+        return true;
+    }
+
+    public function restore(User $user, MatchResult $match): bool
+    {
+        return true;
+    }
+
+    public function forceDelete(User $user, MatchResult $match): bool
+    {
+        return true;
+    }
+}

--- a/app/Services/EntryService.php
+++ b/app/Services/EntryService.php
@@ -102,6 +102,20 @@ class EntryService
     }
 
     /**
+     * Improve the current handicap held for an entry
+     */
+    public function improveEntryHandicap(Entry $entry, int $newHandicap): Entry
+    {
+        if($newHandicap >= $entry->current_handicap) {
+            throw new DomainException("An improved handicap is always a lower number");
+        }
+
+        $entry->update(['current_handicap' => $newHandicap]);
+
+        return $entry;
+    }
+
+    /**
      * Withdraw from a competition by removing an entry
      */
     public function withdrawFromCompetition(Entry $entry): bool

--- a/app/Services/HandicapService.php
+++ b/app/Services/HandicapService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Handicap;
+
+class HandicapService
+{
+    // Lookup ----
+
+    /**
+     * Recalculate a handicap given a match score
+     */
+    public function recalculateHandicap(Handicap $handicap, int $matchPoints): Handicap
+    {
+        $achievedHandicap = Handicap::orderBy('number')
+            ->whereBowStyle($handicap->bow_style)
+            ->forMatchScore($matchPoints)
+            ->firstOrFail();
+
+        if($achievedHandicap->number >= $handicap->number) {
+            return $handicap;
+        }
+
+        $newNumber = (int)round(
+            collect([$handicap->number, $achievedHandicap->number])->average()
+        );
+
+        return Handicap::whereBowStyle($handicap->bow_style)
+            ->whereNumber($newNumber)
+            ->firstOrFail();
+    }
+}

--- a/app/Services/MatchResultService.php
+++ b/app/Services/MatchResultService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Competition;
 use App\Models\Entry;
 use App\Models\Handicap;
 use App\Models\MatchResult;
@@ -31,10 +32,50 @@ class MatchResultService
 
     public const int CLOSE_LOSS_THRESHOLD = 5;
 
+    // Setup ----
+
     public function __construct(protected HandicapService $handicapService) {}
 
     // Lookup ----
-    //
+
+    /**
+     * Get all match results for the given competition
+     *
+     * @return Collection<int, MatchResult>
+     */
+    public function getMatchResultsForCompetition(Competition $competition): Collection
+    {
+        return MatchResult::inCompetition($competition)
+            ->orderBy('shot_at')
+            ->orderBy('id')
+            ->get();
+    }
+
+    /**
+     * Get all match results for the given stage
+     *
+     * @return Collection<int, MatchResult>
+     */
+    public function getMatchResultsForStage(Stage $stage): Collection
+    {
+        return MatchResult::inStage($stage)
+            ->orderBy('shot_at')
+            ->orderBy('id')
+            ->get();
+    }
+
+    /**
+     * Get all match results for the given round
+     *
+     * @return Collection<int, MatchResult>
+     */
+    public function getMatchResultsForRound(Round $round): Collection
+    {
+        return MatchResult::whereRoundId($round->id)
+            ->orderBy('shot_at')
+            ->orderBy('id')
+            ->get();
+    }
 
     // Management ----
 

--- a/app/Services/MatchResultService.php
+++ b/app/Services/MatchResultService.php
@@ -34,7 +34,11 @@ class MatchResultService
 
     // Setup ----
 
-    public function __construct(protected HandicapService $handicapService) {}
+    public function __construct(
+        protected EntryService $entryService,
+        protected HandicapService $handicapService,
+        protected StandingService $standingService,
+    ) {}
 
     // Lookup ----
 
@@ -115,6 +119,9 @@ class MatchResultService
 
             // Store the result
             $match->save();
+
+            // Aggregate the match result into the standings for the competitors
+            $this->standingService->applyMatchResult($match);
 
             return $match;
         });

--- a/app/Services/MatchResultService.php
+++ b/app/Services/MatchResultService.php
@@ -16,9 +16,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
-/// TODO: Handle side-effects:
-///  - League standings
-///  - Entry handicap updates
 class MatchResultService
 {
     // Constants ----
@@ -129,6 +126,8 @@ class MatchResultService
 
     /**
      * Update an existing match result
+     *
+     * This does not currently cause an update to the standings!
      */
     public function updateMatchResult(MatchResult $match, array $data): MatchResult
     {
@@ -245,11 +244,17 @@ class MatchResultService
 
         $score->save();
 
+        if($score->handicap_after < $score->handicap_before) {
+            $this->entryService->improveEntryHandicap($entry, $newHandicap->number);
+        }
+
         return $score;
     }
 
     /**
      * Update an existing individual score for a match competitor
+     *
+     * This does not currently cause an update to the entry's current handicap!
      */
     protected function updateScore(Score $score, array $data): Score
     {

--- a/app/Services/MatchService.php
+++ b/app/Services/MatchService.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Entry;
+use App\Models\Handicap;
+use App\Models\MatchResult;
+use App\Models\Round;
+use App\Models\Score;
+use App\Models\Stage;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/// TODO: Handle side-effects:
+///  - League standings
+///  - Entry handicap updates
+class MatchService
+{
+    // Constants ----
+
+    public const int LEAGUE_POINTS_FOR_WIN = 3;
+    public const int LEAGUE_POINTS_FOR_DRAW = 1;
+    public const int LEAGUE_POINTS_FOR_LOSS = 0;
+
+    public const int BONUS_POINTS_FOR_HANDICAP_HIT = 1;
+    public const int BONUS_POINTS_FOR_CLOSE_LOSS = 1;
+
+    public const int CLOSE_LOSS_THRESHOLD = 5;
+
+    public function __construct(protected HandicapService $handicapService) {}
+
+    // Lookup ----
+    //
+
+    // Management ----
+
+    /**
+     * Record a new match result
+     */
+    public function recordMatchResult(array $data): MatchResult
+    {
+        return DB::transaction(function () use ($data): MatchResult {
+
+            $stage  = Stage::findOrFail($data['stage_id']);
+            $shotAt = CarbonImmutable::make($data['shot_at']);
+
+            $match = MatchResult::make(['shot_at' => $shotAt]);
+
+            // Determine the round in which this match took place
+            $round = $this->resolveRound($stage, $shotAt);
+            $match->round()->associate($round);
+
+            // Associate the individual scores with the match result
+            $leftScore = $this->recordScore($data['left_score']);
+            $match->leftScore()->associate($leftScore);
+
+            $rightScore = $this->recordScore($data['right_score']);
+            $match->rightScore()->associate($rightScore);
+
+            // Handle a drawn on decisive match outcome
+            if ($leftScore->match_points_adjusted === $rightScore->match_points_adjusted) {
+                $this->handleDrawnMatch($match, $leftScore, $rightScore);
+            } else {
+                $this->handleDecisiveMatch($match, $leftScore, $rightScore);
+            }
+
+            // Store the result
+            $match->save();
+
+            return $match;
+        });
+    }
+
+    /**
+     * Update an existing match result
+     */
+    public function updateMatchResult(MatchResult $match, array $data): MatchResult
+    {
+        return DB::transaction(function () use ($match, $data): MatchResult {
+
+            $stage  = Stage::findOrFail($data['stage_id']);
+            $shotAt = CarbonImmutable::make($data['shot_at']);
+
+            // Determine the round in which this match took place
+            $round = $this->resolveRound($stage, $shotAt);
+            $match->round()->associate($round);
+
+            // Update the individual scores
+            $leftScore  = $this->updateScore($match->leftScore, $data['left_score']);
+            $rightScore = $this->updateScore($match->rightScore, $data['right_score']);
+
+            // Handle a drawn on decisive match outcome
+            if ($leftScore->match_points_adjusted === $rightScore->match_points_adjusted) {
+                $this->handleDrawnMatch($match, $leftScore, $rightScore);
+            } else {
+                $this->handleDecisiveMatch($match, $leftScore, $rightScore);
+            }
+
+            // Update the result
+            $match->update(['shot_at' => $shotAt]);
+
+            return $match;
+        });
+    }
+
+    /**
+     * Remove an existing match result
+     */
+    public function removeMatchResult(MatchResult $match): bool
+    {
+        return DB::transaction(function () use ($match): bool {
+            $matchDeleted = $match->delete();
+
+            $match->leftScore()->delete();
+            $match->rightScore()->delete();
+
+            return $matchDeleted;
+        });
+    }
+
+    // Internals ----
+
+    /**
+     * Find the round in which a match was shot
+     */
+    protected function resolveRound(Stage $stage, CarbonInterface $shotAt): Round
+    {
+        return $stage->rounds()
+            ->whereDate('starts_on', '<=', $shotAt)
+            ->whereDate('ends_on', '>=', $shotAt)
+            ->firstOrFail();
+    }
+
+    /**
+     * Record an individual score for a match competitor
+     */
+    protected function recordScore(array $data): Score
+    {
+        $entry = Entry::findOrFail($data['entry_id']);
+
+        $handicap = Handicap::whereBowStyle($entry->bow_style)
+            ->whereNumber($entry->current_handicap)
+            ->firstOrFail();
+
+        $adjustedPoints = $data['match_points'] + $handicap->match_allowance;
+
+        $newHandicap = $this->handicapService->recalculateHandicap($handicap, $data['match_points']);
+
+        $score = Score::make([
+            'handicap_before'       => $handicap->number,
+            'handicap_after'        => $newHandicap->number,
+            'allowance'             => $handicap->match_allowance,
+            'match_points'          => $data['match_points'],
+            'match_points_adjusted' => $adjustedPoints,
+            'bonus_points'          => $adjustedPoints >= 1440 ? self::BONUS_POINTS_FOR_HANDICAP_HIT : 0,
+            'league_points'         => 0, #This gets added when the scores are compared
+        ]);
+
+        $score->entry()->associate($entry);
+
+        $score->save();
+
+        return $score;
+    }
+
+    /**
+     * Update an existing individual score for a match competitor
+     */
+    protected function updateScore(Score $score, array $data): Score
+    {
+        $entry = Entry::findOrFail($data['entry_id']);
+        $score->entry()->associate($entry);
+
+        $matchShotAt = $score->matchResult->shot_at;
+
+        $handicapNumber = $entry
+            ->scores()
+            ->whereHas('matchResult', fn(Builder|MatchResult $match) => $match->shotBefore($matchShotAt))
+            ->orderBy('handicap_after')
+            ->value('handicap_after');
+
+        $handicap = Handicap::whereBowStyle($entry->bow_style)
+            ->whereNumber($handicapNumber)
+            ->firstOrFail();
+
+        $adjustedPoints = $data['match_points'] + $handicap->match_allowance;
+
+        $newHandicap = $this->handicapService->recalculateHandicap($handicap, $data['match_points']);
+
+        $score->update([
+            'handicap_before'       => $handicap->number,
+            'handicap_after'        => $newHandicap->number,
+            'allowance'             => $handicap->match_allowance,
+            'match_points'          => $data['match_points'],
+            'match_points_adjusted' => $adjustedPoints,
+            'bonus_points'          => $adjustedPoints >= 1440 ? self::BONUS_POINTS_FOR_HANDICAP_HIT : 0,
+            'league_points'         => 0, #This gets added when the scores are compared
+        ]);
+
+        return $score;
+    }
+
+    /**
+     * Handle a match ending in a draw
+     */
+    protected function handleDrawnMatch(MatchResult $match, Score $leftScore, Score $rightScore): void
+    {
+        $leftScore->update(['league_points' => self::LEAGUE_POINTS_FOR_DRAW]);
+        $rightScore->update(['league_points' => self::LEAGUE_POINTS_FOR_DRAW]);
+
+        $match->winner()->dissociate();
+    }
+
+    /**
+     * Handle a match ending with a winner
+     */
+    protected function handleDecisiveMatch(MatchResult $match, Score $leftScore, Score $rightScore): void
+    {
+        /** @var Collection<int, Score> $scores */
+        $scores = collect([$leftScore, $rightScore])->sortByDesc('match_points_adjusted');
+
+        // Process the winning score
+        $winningScore = $scores->first();
+        $winningScore->update(['league_points' => self::LEAGUE_POINTS_FOR_WIN]);
+
+        $match->winner()->associate($winningScore->entry);
+
+        // Process the losing score
+        $losingScore = $scores->last();
+        $losingScore->update(['league_points' => self::LEAGUE_POINTS_FOR_LOSS]);
+
+        $matchPointsDifference = $winningScore->match_points_adjusted - $losingScore->match_points_adjusted;
+
+        if ($matchPointsDifference <= self::CLOSE_LOSS_THRESHOLD) {
+            $losingScore->increment('bonus_points', self::BONUS_POINTS_FOR_CLOSE_LOSS);
+        }
+    }
+}

--- a/app/Services/StandingService.php
+++ b/app/Services/StandingService.php
@@ -5,10 +5,13 @@ namespace App\Services;
 use App\Enums\StageType;
 use App\Models\Competition;
 use App\Models\Entry;
+use App\Models\MatchResult;
+use App\Models\Score;
 use App\Models\Stage;
 use App\Models\Standing;
 use DomainException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 
 class StandingService
@@ -50,4 +53,46 @@ class StandingService
             ->create(['entry_id' => $entry->id]);
     }
 
+    /**
+     * Add the given match result to the competitor standings for the appropriate stage
+     */
+    public function applyMatchResult(MatchResult $match): void
+    {
+        /** @var Score[] $scores */
+        $scores = [$match->leftScore, $match->rightScore];
+
+        DB::transaction(function () use ($match, $scores) {
+            foreach ($scores as $score) {
+                $standing = $score->entry
+                    ->standings()
+                    ->whereStageId($match->round->stage_id)
+                    ->firstOrFail();
+
+                $this->aggregateMatchScoreIntoStanding($match, $score, $standing);
+            }
+        });
+    }
+
+    // Internals ----
+
+    /**
+     * Aggregate a match score into the given standing
+     */
+    protected function aggregateMatchScoreIntoStanding(MatchResult $match, Score $score, Standing $standing): void
+    {
+        $isWinner = $match->has_winner && $match->winner->is($score->entry);
+        $isLoser  = $match->has_winner && $match->winner->isNot($score->entry);
+
+        Standing::whereId($standing->id)->incrementEach([
+            'matches_played'        => 1,
+            'matches_won'           => (int)$isWinner,
+            'matches_drawn'         => (int)$match->is_draw,
+            'matches_lost'          => (int)$isLoser,
+            'match_points'          => $score->match_points,
+            'match_points_adjusted' => $score->match_points_adjusted,
+            'bonus_points'          => $score->bonus_points,
+            'league_points'         => $score->league_points,
+            'total_points'          => $score->bonus_points + $score->league_points,
+        ]);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "proprietary",
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "laravel/framework": "^11.31",
         "laravel/tinker": "^2.9"
     },

--- a/database/factories/MatchFactory.php
+++ b/database/factories/MatchFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Entry;
+use App\Models\MatchResult;
+use App\Models\Round;
+use App\Models\Score;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+class MatchFactory extends Factory
+{
+    protected $model = MatchResult::class;
+
+    public function definition(): array
+    {
+        return [
+            'round_id'       => Round::factory(),
+            'left_score_id'  => Score::factory(),
+            'right_score_id' => Score::factory(),
+            'winner_id'      => fake()->optional(0.7)->passthrough(Entry::factory()),
+            'shot_at'        => CarbonImmutable::make(fake()->dateTimeBetween('-2months')),
+            'created_at'     => Carbon::now(),
+            'updated_at'     => Carbon::now(),
+        ];
+    }
+}

--- a/database/factories/ScoreFactory.php
+++ b/database/factories/ScoreFactory.php
@@ -5,7 +5,7 @@ namespace Database\Factories;
 use App\Models\Entry;
 use App\Models\Handicap;
 use App\Models\Score;
-use App\Services\MatchService;
+use App\Services\MatchResultService;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
@@ -43,21 +43,21 @@ class ScoreFactory extends Factory
     public function win(): self
     {
         return $this->state(fn() => [
-            'league_points' => MatchService::LEAGUE_POINTS_FOR_WIN,
+            'league_points' => MatchResultService::LEAGUE_POINTS_FOR_WIN,
         ]);
     }
 
     public function draw(): self
     {
         return $this->state(fn() => [
-            'league_points' => MatchService::LEAGUE_POINTS_FOR_DRAW,
+            'league_points' => MatchResultService::LEAGUE_POINTS_FOR_DRAW,
         ]);
     }
 
     public function loss(): self
     {
         return $this->state(fn() => [
-            'league_points' => MatchService::LEAGUE_POINTS_FOR_LOSS,
+            'league_points' => MatchResultService::LEAGUE_POINTS_FOR_LOSS,
         ]);
     }
 }

--- a/database/factories/ScoreFactory.php
+++ b/database/factories/ScoreFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Entry;
+use App\Models\Handicap;
+use App\Models\Score;
+use App\Services\MatchService;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+class ScoreFactory extends Factory
+{
+    protected $model = Score::class;
+
+    public function definition(): array
+    {
+        $handicapBefore = Handicap::inRandomOrder()->first();
+        $handicapAfter  = Handicap::whereBowStyle($handicapBefore->bow_style)
+            ->where('number', '<=', $handicapBefore->number)
+            ->where('number', '>', $handicapBefore->number - 10)
+            ->first();
+
+        $points         = fake()->numberBetween(0, 150);
+        $pointsAdjusted = $points + $handicapBefore->match_allowance;
+
+        return [
+            'entry_id'              => Entry::factory(),
+            'handicap_before'       => $handicapBefore->number,
+            'handicap_after'        => $handicapAfter->number,
+            'allowance'             => $handicapBefore->match_allowance,
+            'match_points'          => $points,
+            'match_points_adjusted' => $pointsAdjusted,
+            'bonus_points'          => $points >= 1440 ? 1 : 0,
+            'league_points'         => fake()->randomElement([0, 2]),
+            'created_at'            => Carbon::now(),
+            'updated_at'            => Carbon::now(),
+        ];
+    }
+
+    // States ----
+
+    public function win(): self
+    {
+        return $this->state(fn() => [
+            'league_points' => MatchService::LEAGUE_POINTS_FOR_WIN,
+        ]);
+    }
+
+    public function draw(): self
+    {
+        return $this->state(fn() => [
+            'league_points' => MatchService::LEAGUE_POINTS_FOR_DRAW,
+        ]);
+    }
+
+    public function loss(): self
+    {
+        return $this->state(fn() => [
+            'league_points' => MatchService::LEAGUE_POINTS_FOR_LOSS,
+        ]);
+    }
+}

--- a/database/factories/StandingFactory.php
+++ b/database/factories/StandingFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Entry;
 use App\Models\Stage;
 use App\Models\Standing;
+use App\Services\MatchResultService;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
@@ -21,6 +22,10 @@ class StandingFactory extends Factory
 
         $bonusPoints = fake()->numberBetween(0, $matchesWon);
 
+        $winPoints    = $matchesWon * MatchResultService::LEAGUE_POINTS_FOR_WIN;
+        $drawPoints   = $matchesDrawn * MatchResultService::LEAGUE_POINTS_FOR_DRAW;
+        $leaguePoints = $winPoints + $drawPoints;
+
         return [
             'stage_id'              => Stage::factory(),
             'entry_id'              => Entry::factory(),
@@ -31,7 +36,8 @@ class StandingFactory extends Factory
             'match_points'          => $matchesPlayed * 135,
             'match_points_adjusted' => $matchesPlayed * 1440,
             'bonus_points'          => $bonusPoints,
-            'league_points'         => ($matchesWon * 2) + $matchesDrawn + $bonusPoints,
+            'league_points'         => $leaguePoints,
+            'total_points'          => $leaguePoints + $bonusPoints,
             'created_at'            => Carbon::now(),
             'updated_at'            => Carbon::now(),
         ];

--- a/database/migrations/2024_12_15_230816_create_standings_table.php
+++ b/database/migrations/2024_12_15_230816_create_standings_table.php
@@ -21,6 +21,7 @@ return new class extends Migration {
             $table->unsignedMediumInteger('match_points_adjusted')->default(0);
             $table->unsignedTinyInteger('bonus_points')->default(0);
             $table->unsignedTinyInteger('league_points')->default(0);
+            $table->unsignedTinyInteger('total_points')->default(0);
 
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2024_12_17_194256_create_scores_table.php
+++ b/database/migrations/2024_12_17_194256_create_scores_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('scores', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('entry_id')->constrained('entries');
+
+            $table->unsignedTinyInteger('handicap_before');
+            $table->unsignedTinyInteger('handicap_after');
+            $table->unsignedMediumInteger('allowance');
+            $table->unsignedTinyInteger('match_points');
+            $table->unsignedMediumInteger('match_points_adjusted');
+            $table->unsignedTinyInteger('bonus_points');
+            $table->unsignedTinyInteger('league_points');
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('scores');
+    }
+};

--- a/database/migrations/2024_12_17_195633_create_matches_table.php
+++ b/database/migrations/2024_12_17_195633_create_matches_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('match_results', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('round_id')->constrained('rounds');
+            $table->foreignId('left_score_id')->constrained('scores');
+            $table->foreignId('right_score_id')->constrained('scores');
+            $table->foreignId('winner_id')->nullable()->constrained('entries');
+
+            $table->dateTime('shot_at')->index();
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('match_results');
+    }
+};

--- a/resources/views/competitions/partials/league-table.blade.php
+++ b/resources/views/competitions/partials/league-table.blade.php
@@ -25,20 +25,20 @@
                         <td class="whitespace-nowrap py-4 pl-5 pr-3 text-center text-sm font-medium text-gray-700 dark:text-gray-200">
                             @if($index == 0)
                                 <span class="inline-flex items-center rounded-md bg-yellow-400/10 px-2 py-1 text-xs font-medium text-yellow-400 ring-1 ring-inset ring-yellow-400/30">
-                                                        1
-                                                    </span>
+                                    1
+                                </span>
                             @elseif($index == 1)
                                 <span class="inline-flex items-center rounded-md bg-gray-400/10 px-2 py-1 text-xs font-medium text-gray-400 ring-1 ring-inset ring-gray-400/30">
-                                                        2
-                                                    </span>
+                                    2
+                                </span>
                             @elseif($index == 2)
                                 <span class="inline-flex items-center rounded-md bg-orange-400/10 px-2 py-1 text-xs font-medium text-orange-400 ring-1 ring-inset ring-orange-400/30">
-                                                        3
-                                                    </span>
+                                    3
+                                </span>
                             @elseif($index <= 7)
                                 <span class="inline-flex items-center rounded-md bg-green-400/10 px-2 py-1 text-xs font-medium text-green-400 ring-1 ring-inset ring-green-400/30">
-                                                        {{$index + 1}}
-                                                    </span>
+                                    {{$index + 1}}
+                                </span>
                             @else
                                 {{$index + 1}}
                             @endif
@@ -53,7 +53,7 @@
                         <td class="whitespace-nowrap px-3 py-5 text-right text-sm text-gray-500 dark:text-gray-400">{{number_format($standing->match_points)}}</td>
                         <td class="whitespace-nowrap px-3 py-5 text-right text-sm text-gray-500 dark:text-gray-400">{{number_format($standing->match_points_adjusted)}}</td>
                         <td class="whitespace-nowrap px-3 py-5 text-right text-sm text-gray-500 dark:text-gray-400">{{$standing->bonus_points}}</td>
-                        <td class="whitespace-nowrap px-3 py-5 text-center text-lg text-gray-700 dark:text-gray-200">{{$standing->league_points}}</td>
+                        <td class="whitespace-nowrap px-3 py-5 text-center text-lg text-gray-700 dark:text-gray-200">{{$standing->total_points}}</td>
                     </tr>
                 @endforeach
                 </tbody>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -43,7 +43,7 @@
                                 League Starts
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
-                                {{$competition->stages[0]->starts_on->toFormattedDateString()}}
+                                {{$stages[0]->starts_on->toFormattedDateString()}}
                             </dd>
                         </div>
 
@@ -52,7 +52,7 @@
                                 Playoff Date
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
-                                {{$competition->stages[1]->starts_on->toFormattedDateString()}}
+                                {{$stages[1]->starts_on->toFormattedDateString()}}
                             </dd>
                         </div>
 
@@ -79,7 +79,7 @@
                                 Playoff Spaces
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
-                                {{$competition->stages[1]->capacity}}
+                                {{$stages[1]->capacity}}
                             </dd>
                         </div>
                     </dl>
@@ -106,9 +106,11 @@
                                     </p>
                                 </div>
                                 <div class="ml-4 mt-4 shrink-0">
-                                    {{--                                    <x-primary-button>--}}
-                                    {{--                                      Match--}}
-                                    {{--                                    </x-primary-button>--}}
+                                    <a href="{{route('competitions.stages.matches.create', [$competition, $stages[0]])}}">
+                                        <x-primary-button>
+                                            Match
+                                        </x-primary-button>
+                                    </a>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/matches/create.blade.php
+++ b/resources/views/matches/create.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{__('Record Match for') . ' ' . $competition->name}}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="p-6 text-gray-900 dark:text-gray-100">
+                <div class="w-full px-6 py-4 bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
+                    @include('matches.partials.match-form')
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/matches/partials/match-form.blade.php
+++ b/resources/views/matches/partials/match-form.blade.php
@@ -1,0 +1,158 @@
+<form
+    action="{{isset($match)? route('competitions.stages.matches.update', [$competition, $stage, $match]) : route('competitions.stages.matches.store', [$competition, $stage])}}"
+    method="POST"
+>
+    @csrf
+    @isset($match)
+        @method('PUT')
+    @endisset
+
+    <div class="space-y-4 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-4 sm:gap-y-6">
+
+        {{--Date/Time--}}
+        <div>
+            <x-input-label for="shotAt" :value="__('Match Date & Time')"/>
+            <x-text-input
+                type="datetime-local"
+                class="block mt-1 w-full"
+                id="shotAt"
+                name="shot_at"
+                autocomplete="off"
+                required
+                :value="old('shot_at', isset($match)? $match->shot_at->toDateTimeString() : '')"
+            />
+            <x-input-error :messages="$errors->get('shot_at')" class="mt-2"/>
+        </div>
+
+        <h3 class="col-span-2 hidden sm:block">Scores</h3>
+
+        {{--Left Side--}}
+        <div class="space-y-4 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-4 sm:gap-y-6">
+
+            <h4 class="sm:hidden mt-8 text-sm">{{__('Left Side')}}</h4>
+
+            {{--Entry--}}
+            <div>
+                <x-input-label for="leftEntryId" :value="__('Name')"/>
+                <div class="mt-1 grid grid-cols-1">
+                    <select
+                        id="leftEntryId"
+                        name="left_score[entry_id]"
+                        autocomplete="off"
+                        required
+                        class="col-start-1 row-start-1 w-full h-[42px] appearance-none bg-none rounded-md bg-white dark:bg-gray-900 py-1.5 pl-3 pr-8 text-base text-gray-900 dark:text-gray-200 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-700 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+                    >
+                        <option value="" disabled {{ (!isset($match) || !$match->leftScore->entry_id)? 'selected' : '' }}>
+                            Select person...
+                        </option>
+
+                        @foreach($entries as $entry)
+                            <option
+                                value="{{$entry->id}}"
+                                {{isset($match) && $match->leftScore->entry->is($entry)? 'selected' : ''}}
+                            >
+                                {{$entry->person->full_name}}
+                            </option>
+                        @endforeach
+                    </select>
+                    <svg
+                        class="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-500 sm:size-4"
+                        viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" data-slot="icon">
+                        <path fill-rule="evenodd"
+                              d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z"
+                              clip-rule="evenodd"
+                        />
+                    </svg>
+                </div>
+                <x-input-error :messages="$errors->get('left_score.entry_id')" class="mt-2"/>
+            </div>
+
+            {{--Match Points--}}
+            <div class="sm:pr-10">
+                <x-input-label for="leftMatchPoints" :value="__('Match Points')"/>
+                <x-text-input
+                    type="number"
+                    class="block mt-1 w-full"
+                    id="leftMatchPoints"
+                    name="left_score[match_points]"
+                    min="0"
+                    max="150"
+                    autocomplete="off"
+                    required
+                    :value="old('left_score.match_points', isset($match)? $match->leftScore->match_points : '')"
+                />
+                <x-input-error :messages="$errors->get('left_score.match_points')" class="mt-2"/>
+            </div>
+        </div>
+
+
+        {{--Right Side--}}
+        <div class="space-y-4 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-4 sm:gap-y-6">
+
+            <h4 class="sm:hidden mt-8 text-sm">{{__('Right Side')}}</h4>
+
+            {{--Entry--}}
+            <div class="sm:col-start-2 sm:row-start-1">
+                <x-input-label for="rightEntryId" :value="__('Name')"/>
+                <div class="mt-1 grid grid-cols-1">
+                    <select
+                        id="rightEntryId"
+                        name="right_score[entry_id]"
+                        autocomplete="off"
+                        required
+                        class="col-start-1 row-start-1 w-full h-[42px] appearance-none bg-none rounded-md bg-white dark:bg-gray-900 py-1.5 pl-3 pr-8 text-base text-gray-900 dark:text-gray-200 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-700 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+                    >
+                        <option value="" disabled {{ (!isset($match) || !$match->rightScore->entry_id)? 'selected' : '' }}>
+                            Select person...
+                        </option>
+
+                        @foreach($entries as $entry)
+                            <option
+                                value="{{$entry->id}}"
+                                {{isset($match) && $match->rightScore->entry->is($entry)? 'selected' : ''}}
+                            >
+                                {{$entry->person->full_name}}
+                            </option>
+                        @endforeach
+                    </select>
+                    <svg
+                        class="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-500 sm:size-4"
+                        viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" data-slot="icon">
+                        <path fill-rule="evenodd"
+                              d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z"
+                              clip-rule="evenodd"
+                        />
+                    </svg>
+                </div>
+                <x-input-error :messages="$errors->get('right_score.entry_id')" class="mt-2"/>
+            </div>
+
+            {{--Match Points--}}
+            <div class="sm:col-start-1 sm:row-start-1 sm:pl-10">
+                <x-input-label for="rightMatchPoints" :value="__('Match Points')"/>
+                <x-text-input
+                    type="number"
+                    class="block mt-1 w-full"
+                    id="rightMatchPoints"
+                    name="right_score[match_points]"
+                    min="0"
+                    max="150"
+                    autocomplete="off"
+                    required
+                    :value="old('right_score.match_points', isset($match)? $match->rightScore->match_points : '')"
+                />
+                <x-input-error :messages="$errors->get('right_score.match_points')" class="mt-2"/>
+            </div>
+        </div>
+    </div>
+
+    <div class="flex items-center justify-end mt-4" x-data>
+        <x-secondary-button @click="history.back()">
+            {{__('Cancel')}}
+        </x-secondary-button>
+
+        <x-primary-button class="ms-3">
+            {{ __('Save') }}
+        </x-primary-button>
+    </div>
+</form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\CompetitionController;
 use App\Http\Controllers\EntryController;
+use App\Http\Controllers\MatchResultController;
 use App\Http\Controllers\PersonController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
@@ -21,7 +22,8 @@ Route::middleware('auth')->group(function () {
 
     Route::resource('people', PersonController::class);
     Route::resource('competitions', CompetitionController::class);
-    Route::resource('competitions.entries', EntryController::class);
+    Route::resource('competitions.entries', EntryController::class)->scoped();
+    Route::resource('competitions.stages.matches', MatchResultController::class)->scoped();
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
This adds basic match score recording functionality. When matches are recorded, the league standings are updated accordingly. Each entry's current handicap is also recalculated appropriately.

Closes #7