### PR TITLE
Add match history to competition details

### DIFF
--- a/app/Http/Controllers/CompetitionController.php
+++ b/app/Http/Controllers/CompetitionController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\CompetitionRequest;
 use App\Models\Competition;
 use App\Services\CompetitionService;
 use App\Services\EntryService;
+use App\Services\MatchResultService;
 use App\Services\StandingService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
@@ -16,6 +17,7 @@ class CompetitionController extends Controller
     public function __construct(
         protected CompetitionService $competitionService,
         protected EntryService       $entryService,
+        protected MatchResultService $matchResultService,
         protected StandingService    $standingService,
     ) {}
 
@@ -51,12 +53,14 @@ class CompetitionController extends Controller
         $competition = $this->competitionService->findCompetition($competition->id);
         $entries     = $this->entryService->getCompetitionEntries($competition);
         $standings   = $this->standingService->getLeagueStandingsForCompetition($competition);
+        $matches     = $this->matchResultService->getRecentMatchResultsForCompetition($competition);
 
         return view('competitions.show', [
             'competition' => $competition,
             'stages'      => $competition->stages,
             'entries'     => $entries,
             'standings'   => $standings,
+            'matches'     => $matches,
         ]);
     }
 

--- a/app/Http/Controllers/CompetitionController.php
+++ b/app/Http/Controllers/CompetitionController.php
@@ -54,6 +54,7 @@ class CompetitionController extends Controller
         $entries     = $this->entryService->getCompetitionEntries($competition);
         $standings   = $this->standingService->getLeagueStandingsForCompetition($competition);
         $matches     = $this->matchResultService->getRecentMatchResultsForCompetition($competition);
+        $matchCount  = $this->matchResultService->countMatchResultsForCompetition($competition);
 
         return view('competitions.show', [
             'competition' => $competition,
@@ -61,6 +62,7 @@ class CompetitionController extends Controller
             'entries'     => $entries,
             'standings'   => $standings,
             'matches'     => $matches,
+            'matchCount'  => $matchCount,
         ]);
     }
 

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -44,7 +44,7 @@ class EntryController extends Controller
     {
         $this->entryService->enterCompetition($competition, $request->validated());
 
-        return redirect()->route('competitions.show', [$competition]);
+        return redirect()->route('competitions.entries.index', [$competition]);
     }
 
     public function show(Competition $competition, Entry $entry): View
@@ -75,13 +75,13 @@ class EntryController extends Controller
     {
         $this->entryService->updateEntry($entry, $request->validated());
 
-        return redirect()->route('competitions.show', [$competition]);
+        return redirect()->route('competitions.entries.index', [$competition]);
     }
 
     public function destroy(Competition $competition, Entry $entry): RedirectResponse
     {
         $this->entryService->withdrawFromCompetition($entry);
 
-        return redirect()->route('competitions.show', [$competition]);
+        return redirect()->route('competitions.entries.index', [$competition]);
     }
 }

--- a/app/Http/Controllers/MatchResultController.php
+++ b/app/Http/Controllers/MatchResultController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\MatchResultRequest;
 use App\Models\Competition;
 use App\Models\MatchResult;
 use App\Models\Stage;
+use App\Services\CompetitionService;
 use App\Services\EntryService;
 use App\Services\MatchResultService;
 use Illuminate\Http\RedirectResponse;
@@ -14,17 +15,20 @@ use Illuminate\View\View;
 class MatchResultController extends Controller
 {
     public function __construct(
+        protected CompetitionService $competitionService,
         protected EntryService       $entryService,
         protected MatchResultService $matchResultService,
     ) {}
 
     public function index(Competition $competition, Stage $stage): View
     {
+        $rounds  = $this->competitionService->getRoundsForStage($stage);
         $matches = $this->matchResultService->getMatchResultsForStage($stage);
 
         return view('matches.index', [
             'competition' => $competition,
             'stage'       => $stage,
+            'rounds'      => $rounds,
             'matches'     => $matches,
         ]);
     }

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -42,6 +42,11 @@ class Competition extends Model
         return Attribute::get(fn() => $this->starts_on->toPeriod($this->ends_on));
     }
 
+    public function isFull(): Attribute
+    {
+        return Attribute::get(fn() => $this->entries()->count() >= $this->stages()->first()->capacity);
+    }
+
     public function status(): Attribute
     {
         return Attribute::get(fn() => match (true) {

--- a/app/Models/Round.php
+++ b/app/Models/Round.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -25,6 +26,13 @@ class Round extends Model
             'starts_on' => 'immutable_date',
             'ends_on'   => 'immutable_date',
         ];
+    }
+
+    // Attributes ----
+
+    public function period(): Attribute
+    {
+        return Attribute::get(fn() => $this->starts_on->toPeriod($this->ends_on));
     }
 
     // Relationships ----

--- a/app/Models/Score.php
+++ b/app/Models/Score.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -33,6 +34,13 @@ class Score extends Model
         'bonus_points'          => 'integer',
         'league_points'         => 'integer',
     ];
+
+    // Attributes ----
+
+    public function handicapChange(): Attribute
+    {
+        return Attribute::get(fn() => $this->handicap_before - $this->handicap_after);
+    }
 
     // Relationships ----
 

--- a/app/Services/CompetitionService.php
+++ b/app/Services/CompetitionService.php
@@ -41,6 +41,21 @@ class CompetitionService
             ->find($id);
     }
 
+    /**
+     * Get all rounds for the given competition stage
+     *
+     * @param Stage $stage
+     *
+     * @return Collection<int, Round>
+     */
+    public function getRoundsForStage(Stage $stage): Collection
+    {
+        return $stage
+            ->rounds()
+            ->orderBy('starts_on')
+            ->get();
+    }
+
     // Management ----
 
     /**

--- a/app/Services/MatchResultService.php
+++ b/app/Services/MatchResultService.php
@@ -40,6 +40,14 @@ class MatchResultService
     // Lookup ----
 
     /**
+     * Count all match results for the given competition
+     */
+    public function countMatchResultsForCompetition(Competition $competition): int
+    {
+        return MatchResult::inCompetition($competition)->count();
+    }
+
+    /**
      * Get all match results for the given competition
      *
      * @return Collection<int, MatchResult>

--- a/app/Services/MatchResultService.php
+++ b/app/Services/MatchResultService.php
@@ -53,6 +53,25 @@ class MatchResultService
     }
 
     /**
+     * Get recent match results for the given competition
+     *
+     * @return Collection<int, MatchResult>
+     */
+    public function getRecentMatchResultsForCompetition(Competition $competition): Collection
+    {
+        return MatchResult::inCompetition($competition)
+            ->with([
+                'winner',
+                'leftScore', 'leftScore.entry', 'leftScore.entry.person',
+                'rightScore', 'rightScore.entry', 'rightScore.entry.person',
+            ])
+            ->orderByDesc('shot_at')
+            ->orderBy('id')
+            ->limit(6)
+            ->get();
+    }
+
+    /**
      * Get all match results for the given stage
      *
      * @return Collection<int, MatchResult>

--- a/resources/views/competitions/entries/index.blade.php
+++ b/resources/views/competitions/entries/index.blade.php
@@ -1,0 +1,87 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{$competition->name}} {{__('Entries')}}
+        </h2>
+    </x-slot>
+
+    <x-slot name="actions">
+        <a href="{{route('competitions.entries.create', $competition)}}">
+            <x-primary-button type="button" :disabled="!$competition->entry_period->isInProgress() || $competition->is_full">
+                Enter
+            </x-primary-button>
+        </a>
+    </x-slot>
+
+    {{--Breadcrumbs--}}
+    <x-slot name="breadcrumbs">
+        <x-breadcrumbs :crumbs="[
+            $competition->name => route('competitions.show', $competition),
+            'Entries' => ''
+        ]"/>
+    </x-slot>
+
+    {{--Entries--}}
+    <div>
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="p-6 text-gray-900 dark:text-gray-100">
+                <div class="w-full bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
+
+                    <div class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-5 sm:px-6">
+                        <div class="-ml-4 -mt-4 flex flex-wrap items-center justify-between sm:flex-nowrap">
+                            <div class="ml-4 mt-4">
+                                <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                    All Entries
+                                </h3>
+                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                    Entries are currently {{$competition->entry_period->isInProgress()? 'open' : 'closed'}}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    @if($entries->isEmpty())
+                        <div class="p-6 text-center">
+                            No entries yet.
+                        </div>
+                    @endif
+
+                    <ul role="list" class="divide-y divide-gray-100 dark:divide-gray-700">
+                        @foreach($entries as $entry)
+                            <li class="flex justify-between gap-x-6 px-6 py-5">
+                                <div class="flex min-w-0 gap-x-4">
+                                    <img
+                                        class="size-12 flex-none rounded-full bg-gray-50 dark:bg-gray-800"
+                                        src="https://placehold.co/200x200?text={{$entry->person->initials}}"
+                                        alt="{{$entry->person->initials}}"
+                                    >
+                                    <div class="min-w-0 flex-auto">
+                                        <p class="text-sm/6 font-semibold text-gray-900 dark:text-gray-100">
+                                            <a href="{{route('people.show', $entry->person)}}" class="hover:underline">
+                                                {{$entry->person->full_name}}
+                                            </a>
+                                        </p>
+                                        <p class="mt-1 flex text-xs/5 text-gray-500 dark:text-gray-400">
+                                            {{$entry->bow_style->name}}
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="flex shrink-0 items-center gap-x-6">
+                                    <div class="hidden sm:flex sm:flex-col sm:items-end">
+                                        <p class="text-sm/6 text-gray-900 dark:text-gray-100">Current Handicap: {{$entry->current_handicap}}</p>
+                                        <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">Initial Handicap: {{$entry->initial_handicap}}</p>
+                                    </div>
+                                    <a href="{{route('competitions.entries.edit', [$competition, $entry])}}">
+                                        <x-secondary-button>
+                                            Edit
+                                        </x-secondary-button>
+                                    </a>
+                                </div>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -67,7 +67,13 @@
 
                         <div class="border-b sm:border-0 border-gray-100 dark:border-gray-700 px-4 py-6 sm:col-span-1 sm:px-0">
                             <dt class="text-sm/6 font-medium text-gray-900 dark:text-gray-200">
-                                League Entries
+                                <a href="{{route('competitions.entries.index', $competition)}}" class="flex items-center space-x-1">
+                                    <span>League Entries</span>
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                        <path fill-rule="evenodd" d="M8.914 6.025a.75.75 0 0 1 1.06 0 3.5 3.5 0 0 1 0 4.95l-2 2a3.5 3.5 0 0 1-5.396-4.402.75.75 0 0 1 1.251.827 2 2 0 0 0 3.085 2.514l2-2a2 2 0 0 0 0-2.828.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                                        <path fill-rule="evenodd" d="M7.086 9.975a.75.75 0 0 1-1.06 0 3.5 3.5 0 0 1 0-4.95l2-2a3.5 3.5 0 0 1 5.396 4.402.75.75 0 0 1-1.251-.827 2 2 0 0 0-3.085-2.514l-2 2a2 2 0 0 0 0 2.828.75.75 0 0 1 0 1.06Z" clip-rule="evenodd" />
+                                    </svg>
+                                </a>
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
                                 {{$competition->entries_count}}
@@ -121,78 +127,4 @@
             </div>
         </div>
     @endif
-
-    {{--Entries--}}
-    <div class="pt-6">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="p-6 text-gray-900 dark:text-gray-100">
-                <div class="w-full bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
-
-                    <div class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-5 sm:px-6">
-                        <div class="-ml-4 -mt-4 flex flex-wrap items-center justify-between sm:flex-nowrap">
-                            <div class="ml-4 mt-4">
-                                <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
-                                    All Entries
-                                </h3>
-                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                                    Entries are currently {{$competition->entry_period->isInProgress()? 'open' : 'closed'}}
-                                </p>
-                            </div>
-                            <div class="ml-4 mt-4 shrink-0">
-                                <a href="{{route('competitions.entries.create', $competition)}}">
-                                    <x-primary-button
-                                        type="button"
-                                        :disabled="!$competition->entry_period->isInProgress() || $competition->entries_count >= $competition->stages[0]->capacity"
-                                    >
-                                        Enter
-                                    </x-primary-button>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-
-                    @if($entries->isEmpty())
-                        <div class="p-6 text-center">
-                            No entries yet.
-                        </div>
-                    @endif
-
-                    <ul role="list" class="divide-y divide-gray-100 dark:divide-gray-700">
-                        @foreach($entries as $entry)
-                            <li class="flex justify-between gap-x-6 px-6 py-5">
-                                <div class="flex min-w-0 gap-x-4">
-                                    <img
-                                        class="size-12 flex-none rounded-full bg-gray-50 dark:bg-gray-800"
-                                        src="https://placehold.co/200x200?text={{$entry->person->initials}}"
-                                        alt="{{$entry->person->initials}}"
-                                    >
-                                    <div class="min-w-0 flex-auto">
-                                        <p class="text-sm/6 font-semibold text-gray-900 dark:text-gray-100">
-                                            <a href="{{route('people.show', $entry->person)}}" class="hover:underline">
-                                                {{$entry->person->full_name}}
-                                            </a>
-                                        </p>
-                                        <p class="mt-1 flex text-xs/5 text-gray-500 dark:text-gray-400">
-                                            {{$entry->bow_style->name}}
-                                        </p>
-                                    </div>
-                                </div>
-                                <div class="flex shrink-0 items-center gap-x-6">
-                                    <div class="hidden sm:flex sm:flex-col sm:items-end">
-                                        <p class="text-sm/6 text-gray-900 dark:text-gray-100">Current Handicap: {{$entry->current_handicap}}</p>
-                                        <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">Initial Handicap: {{$entry->initial_handicap}}</p>
-                                    </div>
-                                    <a href="{{route('competitions.entries.edit', [$competition, $entry])}}">
-                                        <x-secondary-button>
-                                            Edit
-                                        </x-secondary-button>
-                                    </a>
-                                </div>
-                            </li>
-                        @endforeach
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </div>
 </x-app-layout>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -131,17 +131,22 @@
                         <div class="-ml-4 -mt-4 flex flex-wrap items-center justify-between sm:flex-nowrap">
                             <div class="ml-4 mt-4">
                                 <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
-                                    Recent Matches
+                                    {{__('Recent Matches')}}
                                     <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                                        {{$matchCount}} {{Str::plural('match result', $matchCount)}} recorded
+                                        {{$matchCount}} {{Str::plural('match result', $matchCount)}} {{__('recorded')}}
                                     </p>
                                 </h3>
                             </div>
-                            <div class="ml-4 mt-4 shrink-0">
+                            <div class="ml-4 mt-4 shrink-0 space-x-2">
                                 <a href="{{route('competitions.stages.matches.create', [$competition, $stages[0]])}}">
                                     <x-primary-button>
-                                        Record
+                                        {{__('Record')}}
                                     </x-primary-button>
+                                </a>
+                                <a href="{{route('competitions.stages.matches.index', [$competition, $stages[0]])}}">
+                                    <x-secondary-button>
+                                        {{__('View')}}
+                                    </x-secondary-button>
                                 </a>
                             </div>
                         </div>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -111,13 +111,6 @@
                                         Last updated {{$standings->max('updated_at')->toFormattedDateString()}}
                                     </p>
                                 </div>
-                                <div class="ml-4 mt-4 shrink-0">
-                                    <a href="{{route('competitions.stages.matches.create', [$competition, $stages[0]])}}">
-                                        <x-primary-button>
-                                            Match
-                                        </x-primary-button>
-                                    </a>
-                                </div>
                             </div>
                         </div>
 
@@ -127,4 +120,41 @@
             </div>
         </div>
     @endif
+
+    {{--Recent Matches--}}
+    <div class="pt-6">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="p-6 text-gray-900 dark:text-gray-100">
+                <div class="w-full bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
+
+                    <div class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-5 sm:px-6">
+                        <div class="-ml-4 -mt-4 flex flex-wrap items-center justify-between sm:flex-nowrap">
+                            <div class="ml-4 mt-4">
+                                <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                    Recent Matches
+                                </h3>
+                            </div>
+                            <div class="ml-4 mt-4 shrink-0">
+                                <a href="{{route('competitions.stages.matches.create', [$competition, $stages[0]])}}">
+                                    <x-primary-button>
+                                        Record
+                                    </x-primary-button>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="pb-5 sm:pb-6">
+                        <ul class="flex-col space-y-4 divide-y dark:divide-gray-700">
+                            @foreach($matches as $match)
+                                <li class="pt-2">
+                                    <x-match-result :match="$match"/>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </x-app-layout>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -6,6 +6,16 @@
     </x-slot>
 
     <x-slot name="actions">
+        <a href="{{route('competitions.stages.matches.index', [$competition, $stages[0]])}}">
+            <x-secondary-button>
+                {{__('Matches')}}
+            </x-secondary-button>
+        </a>
+        <a href="{{route('competitions.entries.index', $competition)}}">
+            <x-secondary-button>
+                {{__('Entries')}}
+            </x-secondary-button>
+        </a>
         <a href="{{route('competitions.edit', $competition)}}">
             <x-secondary-button type="button">
                 Edit
@@ -69,10 +79,12 @@
                             <dt class="text-sm/6 font-medium text-gray-900 dark:text-gray-200">
                                 <a href="{{route('competitions.entries.index', $competition)}}" class="flex items-center space-x-1">
                                     <span>League Entries</span>
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
-                                        <path fill-rule="evenodd" d="M8.914 6.025a.75.75 0 0 1 1.06 0 3.5 3.5 0 0 1 0 4.95l-2 2a3.5 3.5 0 0 1-5.396-4.402.75.75 0 0 1 1.251.827 2 2 0 0 0 3.085 2.514l2-2a2 2 0 0 0 0-2.828.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
-                                        <path fill-rule="evenodd" d="M7.086 9.975a.75.75 0 0 1-1.06 0 3.5 3.5 0 0 1 0-4.95l2-2a3.5 3.5 0 0 1 5.396 4.402.75.75 0 0 1-1.251-.827 2 2 0 0 0-3.085-2.514l-2 2a2 2 0 0 0 0 2.828.75.75 0 0 1 0 1.06Z" clip-rule="evenodd" />
-                                    </svg>
+                                    <span class="text-gray-700 dark:text-gray-400">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                            <path fill-rule="evenodd" d="M8.914 6.025a.75.75 0 0 1 1.06 0 3.5 3.5 0 0 1 0 4.95l-2 2a3.5 3.5 0 0 1-5.396-4.402.75.75 0 0 1 1.251.827 2 2 0 0 0 3.085 2.514l2-2a2 2 0 0 0 0-2.828.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                                            <path fill-rule="evenodd" d="M7.086 9.975a.75.75 0 0 1-1.06 0 3.5 3.5 0 0 1 0-4.95l2-2a3.5 3.5 0 0 1 5.396 4.402.75.75 0 0 1-1.251-.827 2 2 0 0 0-3.085-2.514l-2 2a2 2 0 0 0 0 2.828.75.75 0 0 1 0 1.06Z" clip-rule="evenodd" />
+                                        </svg>
+                                    </span>
                                 </a>
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
@@ -145,7 +157,7 @@
                                 </a>
                                 <a href="{{route('competitions.stages.matches.index', [$competition, $stages[0]])}}">
                                     <x-secondary-button>
-                                        {{__('View')}}
+                                        {{__('History')}}
                                     </x-secondary-button>
                                 </a>
                             </div>

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -132,6 +132,9 @@
                             <div class="ml-4 mt-4">
                                 <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
                                     Recent Matches
+                                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                        {{$matchCount}} {{Str::plural('match result', $matchCount)}} recorded
+                                    </p>
                                 </h3>
                             </div>
                             <div class="ml-4 mt-4 shrink-0">

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,0 +1,52 @@
+@props(['crumbs' => []])
+
+@php
+    $crumbs = collect($crumbs);
+@endphp
+
+<nav class="flex border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900" aria-label="Breadcrumb">
+    <ol role="list" class="mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8">
+
+        @foreach($crumbs as $name => $url)
+            @switch($name)
+                @case($crumbs->keys()->first())
+                    <li class="flex">
+                        <div class="flex items-center">
+                            <a href="{{$url}}" class="text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-300">
+                                <svg class="size-5 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+                                    <path fill-rule="evenodd" d="M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z" clip-rule="evenodd" />
+                                </svg>
+                                <span class="sr-only">{{$name}}</span>
+                            </a>
+                        </div>
+                    </li>
+                    @break
+
+                @case($crumbs->keys()->last())
+                    <li class="flex">
+                        <div class="flex items-center">
+                            <svg class="h-full w-6 shrink-0 text-gray-200 dark:text-gray-600" viewBox="0 0 24 44" preserveAspectRatio="none" fill="currentColor" aria-hidden="true">
+                                <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+                            </svg>
+                            <span class="ml-4 text-sm font-medium text-gray-500 dark:text-gray-400" aria-current="page">
+                                {{$name}}
+                            </span>
+                        </div>
+                    </li>
+                    @break
+
+                @default
+                    <li class="flex">
+                        <div class="flex items-center">
+                            <svg class="h-full w-6 shrink-0 text-gray-200 dark:text-gray-600" viewBox="0 0 24 44" preserveAspectRatio="none" fill="currentColor" aria-hidden="true">
+                                <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+                            </svg>
+                            <a href="{{$url}}" class="ml-4 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+                                {{$name}}
+                            </a>
+                        </div>
+                    </li>
+            @endswitch
+        @endforeach
+    </ol>
+</nav>

--- a/resources/views/components/match-result.blade.php
+++ b/resources/views/components/match-result.blade.php
@@ -1,0 +1,117 @@
+@props(['match'])
+
+<div>
+    <div class="text-center dark:text-gray-400 mb-2">
+        {{$match->shot_at->format('l jS F, g:i a')}}
+    </div>
+
+    <div class="flex justify-between items-center">
+        <div class="w-full flex justify-between items-center gap-x-2">
+            <div class="flex gap-x-4 pl-2 sm:pl-8">
+                <img
+                    class="hidden sm:block size-10 rounded-full"
+                    src="https://placehold.co/200x200?text={{$match->leftScore->entry->person->initials}}"
+                    alt="{{$match->leftScore->entry->person->initials}}"
+                >
+                <div class="text-left">
+                    <div class="flex gap-x-2">
+                        <span>{{$match->leftScore->entry->person->full_name}}</span>
+                        <span class="hidden sm:inline">{{$match->winner?->is($match->leftScore->entry)? '👑' : ''}}</span>
+                    </div>
+
+                    <span class="block text-sm text-gray-600 dark:text-gray-400">
+                        {{$match->leftScore->entry->bow_style->name}}
+                    </span>
+                </div>
+            </div>
+
+            <div class="flex flex-row-reverse items-center gap-x-2">
+                <div class="text-2xl {{$match->winner?->is($match->leftScore->entry)? 'font-semibold' : 'font-light text-gray-800 dark:text-gray-200'}}">
+                    {{$match->leftScore->match_points_adjusted}}
+                </div>
+
+                <div>
+                    @switch(true)
+                        @case($match->leftScore->handicap_change > 5)
+                            <span class="text-green-600 dark:text-green-400">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                    <path fill-rule="evenodd" d="M7.47 12.78a.75.75 0 0 0 1.06 0l3.25-3.25a.75.75 0 0 0-1.06-1.06L8 11.19 5.28 8.47a.75.75 0 0 0-1.06 1.06l3.25 3.25ZM4.22 4.53l3.25 3.25a.75.75 0 0 0 1.06 0l3.25-3.25a.75.75 0 0 0-1.06-1.06L8 6.19 5.28 3.47a.75.75 0 0 0-1.06 1.06Z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                            @break
+
+                        @case($match->leftScore->handicap_change > 0)
+                            <span class="text-green-400 dark:text-green-600">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                    <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                            @break
+
+                        @default
+                            <span class="text-gray-600 dark:text-gray-400">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                    <path d="M3.75 7.25a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z" />
+                                </svg>
+                            </span>
+                    @endswitch
+                </div>
+            </div>
+        </div>
+
+        <div class="mx-2 text-gray-600 dark:text-gray-400">-</div>
+
+        <div class="w-full flex flex-row-reverse justify-between items-center gap-x-2">
+            <div class="flex flex-row-reverse gap-x-4 pr-2 sm:pr-8">
+                <img
+                    class="hidden sm:block size-10 rounded-full"
+                    src="https://placehold.co/200x200?text={{$match->rightScore->entry->person->initials}}"
+                    alt="{{$match->rightScore->entry->person->initials}}"
+                >
+                <div class="text-right">
+                    <div class="flex flex-row-reverse gap-x-2">
+                        <span>{{$match->rightScore->entry->person->full_name}}</span>
+                        <span class="hidden sm:inline">{{$match->winner?->is($match->rightScore->entry)? '👑' : ''}}</span>
+                    </div>
+
+                    <div class="text-sm text-gray-600 dark:text-gray-400">
+                        {{$match->rightScore->entry->bow_style->name}}
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex items-center gap-x-2">
+                <div class="text-2xl {{$match->winner?->is($match->rightScore->entry)? 'font-semibold' : 'font-light text-gray-800 dark:text-gray-200'}}">
+                    {{$match->rightScore->match_points_adjusted}}
+                </div>
+
+                <div>
+                    @switch(true)
+                        @case($match->rightScore->handicap_change > 5)
+                            <span class="text-green-600 dark:text-green-400">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                    <path fill-rule="evenodd" d="M7.47 12.78a.75.75 0 0 0 1.06 0l3.25-3.25a.75.75 0 0 0-1.06-1.06L8 11.19 5.28 8.47a.75.75 0 0 0-1.06 1.06l3.25 3.25ZM4.22 4.53l3.25 3.25a.75.75 0 0 0 1.06 0l3.25-3.25a.75.75 0 0 0-1.06-1.06L8 6.19 5.28 3.47a.75.75 0 0 0-1.06 1.06Z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                            @break
+
+                        @case($match->rightScore->handicap_change > 0)
+                            <span class="text-green-400 dark:text-green-600">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                    <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                            @break
+
+                        @default
+                            <span class="text-gray-600 dark:text-gray-400">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                                    <path d="M3.75 7.25a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z" />
+                                </svg>
+                            </span>
+                    @endswitch
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -36,6 +36,11 @@
                 </header>
             @endisset
 
+            <!-- Breadcrumbs -->
+            @isset($breadcrumbs)
+                {{$breadcrumbs}}
+            @endisset
+
             <!-- Page Content -->
             <main>
                 {{ $slot }}

--- a/resources/views/matches/index.blade.php
+++ b/resources/views/matches/index.blade.php
@@ -1,0 +1,78 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{$competition->name}}
+        </h2>
+    </x-slot>
+
+    <x-slot name="actions">
+        <a href="{{route('competitions.stages.matches.create', [$competition, $stage])}}">
+            <x-primary-button>
+                {{__('Record')}}
+            </x-primary-button>
+        </a>
+    </x-slot>
+
+    {{--Breadcrumbs--}}
+    <x-slot name="breadcrumbs">
+        <x-breadcrumbs :crumbs="[
+            $competition->name => route('competitions.show', $competition),
+            'Matches' => ''
+        ]"/>
+    </x-slot>
+
+    {{--Match Results--}}
+    @foreach($rounds->sortByDesc('starts_on') as $round)
+        @if($round->starts_on->isFuture())
+            @continue;
+        @endif
+
+
+        <div class="pt-6">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <div class="w-full bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
+
+                        <div class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-5 sm:px-6">
+                            <div class="-ml-4 -mt-4 flex flex-wrap items-center justify-between sm:flex-nowrap">
+                                <div class="ml-4 mt-4">
+                                    <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                        {{$round->name}}
+                                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                            @switch(true)
+                                                @case($round->period->start->year !== $round->period->end->year)
+                                                    {{$round->period->start->format('jS F Y') . ' - ' . $round->period->end->format('jS F Y')}}
+                                                    @break
+
+                                                @case($round->period->start->month !== $round->period->end->month)
+                                                    {{$round->period->start->format('jS F') . ' - ' . $round->period->end->format('jS F Y')}}
+                                                    @break
+
+                                                @default
+                                                    {{$round->period->start->format('jS') . ' - ' . $round->period->end->format('jS F Y')}}
+                                            @endswitch
+                                        </p>
+                                    </h3>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="pb-5 sm:pb-6">
+                            <ul class="flex-col space-y-4 divide-y dark:divide-gray-700">
+                                @forelse($matches->where('round_id', $round->id)->sortByDesc('shot_at') as $match)
+                                    <li class="pt-2">
+                                        <x-match-result :match="$match"/>
+                                    </li>
+                                @empty
+                                    <li class="px-6 pt-6 text-center">
+                                        No matches have been recorded for this round
+                                    </li>
+                                @endforelse
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endforeach
+</x-app-layout>

--- a/resources/views/matches/index.blade.php
+++ b/resources/views/matches/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{$competition->name}}
+            {{$competition->name}} {{__('Matches')}}
         </h2>
     </x-slot>
 


### PR DESCRIPTION
This adds a full match history page, accessible from the competition details page. The most recent 6 matches in a competition are displayed at the bottom of the competition details page.

Competition entry listing has been moved to a separate page, which is also accessible from the competition details page.

Closes #16