### PR TITLE
Refactor competition stage relationship

### DIFF
--- a/app/Data/CompetitionData.php
+++ b/app/Data/CompetitionData.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Data;
+
+use Carbon\CarbonImmutable;
+
+readonly class CompetitionData
+{
+    public function __construct(
+        public string          $name,
+        public CarbonImmutable $entriesOpenOn,
+        public CarbonImmutable $entriesCloseOn,
+        public StageData       $leagueStage,
+        public StageData       $playoffStage,
+    ) {}
+}

--- a/app/Data/StageData.php
+++ b/app/Data/StageData.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Data;
+
+use App\Enums\StageType;
+use Carbon\CarbonImmutable;
+
+readonly class StageData
+{
+    public function __construct(
+        public StageType       $type,
+        public CarbonImmutable $startsOn,
+        public CarbonImmutable $endsOn,
+    ) {}
+}

--- a/app/Http/Controllers/CompetitionController.php
+++ b/app/Http/Controllers/CompetitionController.php
@@ -41,7 +41,7 @@ class CompetitionController extends Controller
     {
         Gate::authorize('create', Competition::class);
 
-        $this->competitionService->addCompetition($request->validated());
+        $this->competitionService->addCompetition($request->validatedData());
 
         return redirect()->route('competitions.index');
     }
@@ -57,12 +57,13 @@ class CompetitionController extends Controller
         $matchCount  = $this->matchResultService->countMatchResultsForCompetition($competition);
 
         return view('competitions.show', [
-            'competition' => $competition,
-            'stages'      => $competition->stages,
-            'entries'     => $entries,
-            'standings'   => $standings,
-            'matches'     => $matches,
-            'matchCount'  => $matchCount,
+            'competition'  => $competition,
+            'leagueStage'  => $competition->leagueStage,
+            'playoffStage' => $competition->playoffStage,
+            'entries'      => $entries,
+            'standings'    => $standings,
+            'matches'      => $matches,
+            'matchCount'   => $matchCount,
         ]);
     }
 
@@ -79,7 +80,7 @@ class CompetitionController extends Controller
     {
         Gate::authorize('update', $competition);
 
-        $this->competitionService->updateCompetition($competition, $request->validated());
+        $this->competitionService->updateCompetition($competition, $request->validatedData());
 
         return redirect()->route('competitions.index');
     }

--- a/app/Http/Requests/CompetitionRequest.php
+++ b/app/Http/Requests/CompetitionRequest.php
@@ -2,24 +2,56 @@
 
 namespace App\Http\Requests;
 
+use App\Data\CompetitionData;
+use App\Data\StageData;
 use App\Enums\StageType;
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class CompetitionRequest extends FormRequest
 {
     public function rules(): array
     {
         return [
-            'name'               => ['required', 'string', 'min:5', 'max:255'],
-            'entries_open_on'    => ['required', 'date'],
-            'entries_close_on'   => ['required', 'date', 'after:entries_open_on'],
-            'stages'             => ['required', 'array'],
-            'stages.*'           => ['array:id,type,starts_on,ends_on'],
-            'stages.*.id'        => ['filled', 'exists:stages,id'],
-            'stages.*.type'      => ['required', Rule::enum(StageType::class)],
-            'stages.*.starts_on' => ['required', 'date'],
-            'stages.*.ends_on'   => ['required', 'date', 'after_or_equal:stages.*.starts_on'],
+            'name'                     => ['required', 'string', 'min:5', 'max:255'],
+            'entries_open_on'          => ['required', 'date'],
+            'entries_close_on'         => ['required', 'date', 'after:entries_open_on'],
+
+            // Stage Data
+            'stages'                   => ['required', 'array:league,playoff'],
+            'stages.league'            => ['array:starts_on,ends_on'],
+            'stages.league.starts_on'  => ['required', 'date'],
+            'stages.league.ends_on'    => ['required', 'date', 'after_or_equal:stages.league.starts_on'],
+            'stages.playoff'           => ['array:starts_on,ends_on'],
+            'stages.playoff.starts_on' => ['required', 'date'],
+            'stages.playoff.ends_on'   => ['required', 'date', 'after_or_equal:stages.playoff.starts_on'],
         ];
+    }
+
+    public function validatedData(): CompetitionData
+    {
+        return $this->makeCompetitionDto(
+            $this->validated()
+        );
+    }
+
+    protected function makeCompetitionDto(array $data): CompetitionData
+    {
+        return new CompetitionData(
+            name: $data['name'],
+            entriesOpenOn: CarbonImmutable::make($data['entries_open_on']),
+            entriesCloseOn: CarbonImmutable::make($data['entries_close_on']),
+            leagueStage: $this->makeStageDto('league', data_get($data,'stages.league')),
+            playoffStage: $this->makeStageDto('playoff', data_get($data,'stages.playoff')),
+        );
+    }
+
+    protected function makeStageDto(string $type, array $data): StageData
+    {
+        return new StageData(
+            type: StageType::from($type),
+            startsOn: CarbonImmutable::make($data['starts_on']),
+            endsOn: CarbonImmutable::make($data['ends_on']),
+        );
     }
 }

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -2,10 +2,12 @@
 
 namespace App\Models;
 
+use App\Enums\StageType;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Competition extends Model
@@ -61,7 +63,23 @@ class Competition extends Model
 
     public function stages(): HasMany
     {
-        return $this->hasMany(Stage::class);
+        return $this->hasMany(Stage::class)
+            ->orderBy('starts_on')
+            ->orderBy('id');
+    }
+
+    public function leagueStage(): HasOne
+    {
+        return $this->stages()
+            ->where('type', StageType::League)
+            ->one();
+    }
+
+    public function playoffStage(): HasOne
+    {
+        return $this->stages()
+            ->where('type', StageType::Playoff)
+            ->one();
     }
 
     public function entries(): HasMany

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -46,7 +46,7 @@ class Competition extends Model
 
     public function isFull(): Attribute
     {
-        return Attribute::get(fn() => $this->entries()->count() >= $this->stages()->first()->capacity);
+        return Attribute::get(fn() => $this->entries()->count() >= $this->leagueStage->capacity);
     }
 
     public function status(): Attribute

--- a/app/Services/EntryService.php
+++ b/app/Services/EntryService.php
@@ -67,7 +67,7 @@ class EntryService
         $entry->save();
 
         $this->standingService->addStandingForStage(
-            $competition->stages()->first(),
+            $competition->leagueStage,
             $entry
         );
 

--- a/app/Services/StandingService.php
+++ b/app/Services/StandingService.php
@@ -25,7 +25,7 @@ class StandingService
      */
     public function getLeagueStandingsForCompetition(Competition $competition): Collection
     {
-        $stage = $competition->stages->firstWhere('type', StageType::League);
+        $stage = $competition->leagueStage;
 
         return $stage
             ->standings()

--- a/database/factories/CompetitionFactory.php
+++ b/database/factories/CompetitionFactory.php
@@ -2,10 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Enums\StageType;
 use App\Models\Competition;
+use App\Models\Stage;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Carbon;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 
 class CompetitionFactory extends Factory
 {
@@ -34,5 +36,19 @@ class CompetitionFactory extends Factory
             'created_at'       => CarbonImmutable::now(),
             'updated_at'       => CarbonImmutable::now(),
         ];
+    }
+
+    // Helpers ----
+
+    public function withStages(): self
+    {
+        return $this->has(
+            Stage::factory()
+                ->count(2)
+                ->state(new Sequence(
+                    ['type' => StageType::League],
+                    ['type' => StageType::Playoff],
+                ))
+        );
     }
 }

--- a/database/migrations/2024_12_11_202054_create_stages_table.php
+++ b/database/migrations/2024_12_11_202054_create_stages_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
             $table->foreignId('competition_id')->constrained('competitions');
 
             $table->string('name');
-            $table->string('type', 10);
+            $table->string('type', 10)->index();
             $table->unsignedTinyInteger('capacity');
             $table->date('starts_on');
             $table->date('ends_on');

--- a/database/seeders/EntrySeeder.php
+++ b/database/seeders/EntrySeeder.php
@@ -2,10 +2,8 @@
 
 namespace Database\Seeders;
 
-use App\Enums\StageType;
 use App\Models\Competition;
 use App\Models\Entry;
-use App\Models\Person;
 use App\Models\Standing;
 use Illuminate\Database\Seeder;
 
@@ -21,9 +19,7 @@ class EntrySeeder extends Seeder
                 continue;
             }
 
-            $leagueStage = $competition
-                ->stages()
-                ->firstWhere('type', StageType::League);
+            $leagueStage = $competition->leagueStage;
 
             Entry::factory()
                 ->for($competition)

--- a/resources/views/competitions/partials/competition-form.blade.php
+++ b/resources/views/competitions/partials/competition-form.blade.php
@@ -54,12 +54,6 @@
             <x-input-error :messages="$errors->get('entries_close_on')" class="mt-2"/>
         </div>
 
-        @isset($competition)
-            <input type="hidden" name="stages[0][id]" value="{{$competition->stages[0]?->id}}"/>
-        @endisset
-
-        <input type="hidden" name="stages[0][type]" value="league"/>
-
         {{--League Stage Start Date--}}
         <div>
             <x-input-label for="leagueStartsOn" :value="__('League Start Date')" />
@@ -67,12 +61,12 @@
                 type="date"
                 class="block mt-1 w-full"
                 id="leagueStartsOn"
-                name="stages[0][starts_on]"
+                name="stages[league][starts_on]"
                 autocomplete="off"
                 required
-                :value="old('stages.0.starts_on', isset($competition)? $competition->stages[0]?->starts_on->toDateString() : '')"
+                :value="old('stages.league.starts_on', isset($competition)? $competition->leagueStage?->starts_on->toDateString() : '')"
             />
-            <x-input-error :messages="$errors->get('stages.0.starts_on')" class="mt-2"/>
+            <x-input-error :messages="$errors->get('stages.league.starts_on')" class="mt-2"/>
         </div>
 
         {{--League Stage End Date--}}
@@ -82,19 +76,13 @@
                 type="date"
                 class="block mt-1 w-full"
                 id="leagueEndsOn"
-                name="stages[0][ends_on]"
+                name="stages[league][ends_on]"
                 autocomplete="off"
                 required
-                :value="old('stages.0.ends_on', isset($competition)? $competition->stages[0]?->ends_on->toDateString() : '')"
+                :value="old('stages.league.ends_on', isset($competition)? $competition->leagueStage?->ends_on->toDateString() : '')"
             />
-            <x-input-error :messages="$errors->get('stages.0.ends_on')" class="mt-2"/>
+            <x-input-error :messages="$errors->get('stages.league.ends_on')" class="mt-2"/>
         </div>
-
-        @isset($competition)
-            <input type="hidden" name="stages[1][id]" value="{{$competition->stages[0]?->id}}"/>
-        @endisset
-
-        <input type="hidden" name="stages[1][type]" value="playoff"/>
 
         {{--Playoff Stage Start Date--}}
         <div>
@@ -103,12 +91,12 @@
                 type="date"
                 class="block mt-1 w-full"
                 id="playoffStartsOn"
-                name="stages[1][starts_on]"
+                name="stages[playoff][starts_on]"
                 autocomplete="off"
                 required
-                :value="old('stages.1.starts_on', isset($competition)? $competition->stages[1]?->starts_on->toDateString() : '')"
+                :value="old('stages.playoff.starts_on', isset($competition)? $competition->playoffStage?->starts_on->toDateString() : '')"
             />
-            <x-input-error :messages="$errors->get('stages.1.starts_on')" class="mt-2"/>
+            <x-input-error :messages="$errors->get('stages.playoff.starts_on')" class="mt-2"/>
         </div>
 
         {{--Playoff Stage End Date--}}
@@ -118,12 +106,12 @@
                 type="date"
                 class="block mt-1 w-full"
                 id="playoffEndsOn"
-                name="stages[1][ends_on]"
+                name="stages[playoff][ends_on]"
                 autocomplete="off"
                 required
-                :value="old('stages.1.ends_on', isset($competition)? $competition->stages[1]?->ends_on->toDateString() : '')"
+                :value="old('stages.playoff.ends_on', isset($competition)? $competition->playoffStage?->ends_on->toDateString() : '')"
             />
-            <x-input-error :messages="$errors->get('stages.1.ends_on')" class="mt-2"/>
+            <x-input-error :messages="$errors->get('stages.playoff.ends_on')" class="mt-2"/>
         </div>
     </div>
 

--- a/resources/views/competitions/show.blade.php
+++ b/resources/views/competitions/show.blade.php
@@ -6,7 +6,7 @@
     </x-slot>
 
     <x-slot name="actions">
-        <a href="{{route('competitions.stages.matches.index', [$competition, $stages[0]])}}">
+        <a href="{{route('competitions.stages.matches.index', [$competition, $leagueStage])}}">
             <x-secondary-button>
                 {{__('Matches')}}
             </x-secondary-button>
@@ -53,7 +53,7 @@
                                 League Starts
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
-                                {{$stages[0]->starts_on->toFormattedDateString()}}
+                                {{$leagueStage->starts_on->toFormattedDateString()}}
                             </dd>
                         </div>
 
@@ -62,7 +62,7 @@
                                 Playoff Date
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
-                                {{$stages[1]->starts_on->toFormattedDateString()}}
+                                {{$playoffStage->starts_on->toFormattedDateString()}}
                             </dd>
                         </div>
 
@@ -71,7 +71,7 @@
                                 League Spaces
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
-                                {{$competition->stages[0]->capacity}}
+                                {{$leagueStage->capacity}}
                             </dd>
                         </div>
 
@@ -97,7 +97,7 @@
                                 Playoff Spaces
                             </dt>
                             <dd class="mt-1 text-sm/6 text-gray-700 dark:text-gray-400 sm:mt-2">
-                                {{$stages[1]->capacity}}
+                                {{$playoffStage->capacity}}
                             </dd>
                         </div>
                     </dl>
@@ -150,12 +150,12 @@
                                 </h3>
                             </div>
                             <div class="ml-4 mt-4 shrink-0 space-x-2">
-                                <a href="{{route('competitions.stages.matches.create', [$competition, $stages[0]])}}">
+                                <a href="{{route('competitions.stages.matches.create', [$competition, $leagueStage])}}">
                                     <x-primary-button>
                                         {{__('Record')}}
                                     </x-primary-button>
                                 </a>
-                                <a href="{{route('competitions.stages.matches.index', [$competition, $stages[0]])}}">
+                                <a href="{{route('competitions.stages.matches.index', [$competition, $leagueStage])}}">
                                     <x-secondary-button>
                                         {{__('History')}}
                                     </x-secondary-button>

--- a/tests/Feature/CompetitionTest.php
+++ b/tests/Feature/CompetitionTest.php
@@ -33,7 +33,7 @@ test('competition information is displayed', function () {
     $user = User::factory()->create();
 
     $competition = Competition::factory()
-        ->hasStages(2)
+        ->withStages()
         ->create();
 
     $response = $this
@@ -63,13 +63,11 @@ test('new competition can be added', function () {
             'entries_open_on'  => '2023-12-01',
             'entries_close_on' => '2024-01-07',
             'stages'           => [
-                [
-                    'type'      => 'league',
+                'league'  => [
                     'starts_on' => '2024-01-01',
                     'ends_on'   => '2024-03-31',
                 ],
-                [
-                    'type'      => 'playoff',
+                'playoff' => [
                     'starts_on' => '2024-04-01',
                     'ends_on'   => '2024-04-01',
                 ],
@@ -105,7 +103,7 @@ test('competition editing form is displayed', function () {
     $user = User::factory()->create();
 
     $competition = Competition::factory()
-        ->hasStages(2)
+        ->withStages()
         ->create();
 
     $response = $this
@@ -119,7 +117,7 @@ test('competition can be updated', function () {
     $user = User::factory()->create();
 
     $competition = Competition::factory()
-        ->hasStages(2)
+        ->withStages()
         ->create(['name' => 'Indoor League 2024']);
 
     $response = $this
@@ -129,14 +127,11 @@ test('competition can be updated', function () {
             'entries_open_on'  => '2023-12-01',
             'entries_close_on' => '2024-01-07',
             'stages'           => [
-                [
-                    'id'        => $competition->stages[0]->id,
-                    'type'      => 'league',
+                'league'  => [
                     'starts_on' => '2024-01-01',
                     'ends_on'   => '2024-03-31',
                 ],
-                [
-                    'type'      => 'playoff',
+                'playoff' => [
                     'starts_on' => '2024-04-01',
                     'ends_on'   => '2024-04-01',
                 ],
@@ -154,8 +149,8 @@ test('competition can be removed', function () {
     $user = User::factory()->create();
 
     $competition = Competition::factory()
-        ->hasStages(2)
-        ->create();
+        ->withStages()
+        ->create(['name' => 'Indoor League 2024']);
 
     $response = $this
         ->actingAs($user)


### PR DESCRIPTION
This adjusts the relationship between competitions and stages to make it clearer that there is always a league stage and a playoff stage.

Closes #18 