### PR TITLE
Refactor match result score relationship

### DIFF
--- a/app/Data/MatchResultData.php
+++ b/app/Data/MatchResultData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Data;
+
+use Carbon\CarbonImmutable;
+
+readonly class MatchResultData
+{
+    public function __construct(
+        public CarbonImmutable $shotAt,
+        public ScoreData       $leftScore,
+        public ScoreData       $rightScore,
+    ) {}
+}

--- a/app/Data/ScoreData.php
+++ b/app/Data/ScoreData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Data;
+
+use App\Enums\Side;
+
+readonly class ScoreData
+{
+    public function __construct(
+        public Side $side,
+        public int  $entryId,
+        public int  $matchPoints,
+    ) {}
+}

--- a/app/Enums/Side.php
+++ b/app/Enums/Side.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum Side: string
+{
+    case Left = 'left';
+    case Right = 'right';
+}

--- a/app/Http/Controllers/MatchResultController.php
+++ b/app/Http/Controllers/MatchResultController.php
@@ -10,6 +10,7 @@ use App\Services\CompetitionService;
 use App\Services\EntryService;
 use App\Services\MatchResultService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 
 class MatchResultController extends Controller
@@ -22,6 +23,8 @@ class MatchResultController extends Controller
 
     public function index(Competition $competition, Stage $stage): View
     {
+        Gate::authorize('viewAny', MatchResult::class);
+
         $rounds  = $this->competitionService->getRoundsForStage($stage);
         $matches = $this->matchResultService->getMatchResultsForStage($stage);
 
@@ -35,6 +38,8 @@ class MatchResultController extends Controller
 
     public function create(Competition $competition, Stage $stage): View
     {
+        Gate::authorize('create', MatchResult::class);
+
         $entries = $this->entryService->getCompetitionEntries($competition);
 
         return view('matches.create', [
@@ -46,14 +51,17 @@ class MatchResultController extends Controller
 
     public function store(MatchResultRequest $request, Competition $competition, Stage $stage): RedirectResponse
     {
-        $data = $request->validated();
-        $this->matchResultService->recordMatchResult($stage, $data);
+        Gate::authorize('create', MatchResult::class);
+
+        $this->matchResultService->recordMatchResult($stage, $request->validatedData());
 
         return redirect()->route('competitions.show', $competition);
     }
 
     public function show(Competition $competition, Stage $stage, MatchResult $match): View
     {
+        Gate::authorize('view', $match);
+
         return view('matches.show', [
             'competition' => $competition,
             'stage'       => $stage,
@@ -63,6 +71,8 @@ class MatchResultController extends Controller
 
     public function edit(Competition $competition, Stage $stage, MatchResult $match): View
     {
+        Gate::authorize('update', $match);
+
         $entries = $this->entryService->getCompetitionEntries($competition);
 
         return view('matches.edit', [
@@ -75,14 +85,17 @@ class MatchResultController extends Controller
 
     public function update(MatchResultRequest $request, Competition $competition, Stage $stage, MatchResult $match): RedirectResponse
     {
-        $data = $request->validated();
-        $this->matchResultService->updateMatchResult($match, $stage, $data);
+        Gate::authorize('update', $match);
+
+        $this->matchResultService->updateMatchResult($match, $stage, $request->validatedData());
 
         return redirect()->route('competitions.show', $competition);
     }
 
     public function destroy(Competition $competition, Stage $stage, MatchResult $match): RedirectResponse
     {
+        Gate::authorize('delete', $match);
+
         $this->matchResultService->removeMatchResult($match);
 
         return redirect()->route('competitions.show', $competition);

--- a/app/Http/Requests/MatchResultRequest.php
+++ b/app/Http/Requests/MatchResultRequest.php
@@ -2,6 +2,10 @@
 
 namespace App\Http\Requests;
 
+use App\Data\MatchResultData;
+use App\Data\ScoreData;
+use App\Enums\Side;
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Http\FormRequest;
 
 class MatchResultRequest extends FormRequest
@@ -9,13 +13,41 @@ class MatchResultRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'shot_at'                  => ['required', 'date'],
-            'left_score'               => ['required', 'array:entry_id,match_points'],
-            'left_score.entry_id'      => ['required', 'exists:entries,id'],
-            'left_score.match_points'  => ['required', 'integer', 'min:0', 'max:150'],
-            'right_score'              => ['required', 'array:entry_id,match_points'],
-            'right_score.entry_id'     => ['required', 'exists:entries,id', 'different:left_score.entry_id'],
-            'right_score.match_points' => ['required', 'integer', 'min:0', 'max:150'],
+            'shot_at'                   => ['required', 'date'],
+
+            // Score data
+            'scores'                    => ['required', 'array:left,right'],
+            'scores.left'               => ['required', 'array:entry_id,match_points'],
+            'scores.left.entry_id'      => ['required', 'exists:entries,id'],
+            'scores.left.match_points'  => ['required', 'integer', 'min:0', 'max:150'],
+            'scores.right'              => ['required', 'array:entry_id,match_points'],
+            'scores.right.entry_id'     => ['required', 'exists:entries,id'],
+            'scores.right.match_points' => ['required', 'integer', 'min:0', 'max:150'],
         ];
+    }
+
+    public function validatedData(): MatchResultData
+    {
+        return $this->makeMatchResultDto(
+            $this->validated()
+        );
+    }
+
+    protected function makeMatchResultDto(array $data): MatchResultData
+    {
+        return new MatchResultData(
+            shotAt: CarbonImmutable::make($data['shot_at']),
+            leftScore: $this->makeScoreDto('left', data_get($data, 'scores.left')),
+            rightScore: $this->makeScoreDto('right', data_get($data, 'scores.right')),
+        );
+    }
+
+    protected function makeScoreDto(string $side, array $data): ScoreData
+    {
+        return new ScoreData(
+            side: Side::from($side),
+            entryId: $data['entry_id'],
+            matchPoints: $data['match_points'],
+        );
     }
 }

--- a/app/Models/Score.php
+++ b/app/Models/Score.php
@@ -2,11 +2,11 @@
 
 namespace App\Models;
 
+use App\Enums\Side;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Score extends Model
@@ -14,7 +14,9 @@ class Score extends Model
     use HasFactory, SoftDeletes;
 
     protected $fillable = [
+        'match_result_id',
         'entry_id',
+        'side',
         'handicap_before',
         'handicap_after',
         'allowance',
@@ -25,9 +27,12 @@ class Score extends Model
     ];
 
     protected $casts = [
+        'match_result_id'       => 'integer',
         'entry_id'              => 'integer',
+        'side'                  => Side::class,
         'handicap_before'       => 'integer',
         'handicap_after'        => 'integer',
+        'handicap_change'       => 'integer', #TODO: Add this to the table and remove the dynamic attribute
         'allowance'             => 'integer',
         'match_points'          => 'integer',
         'match_points_adjusted' => 'integer',
@@ -49,8 +54,8 @@ class Score extends Model
         return $this->belongsTo(Entry::class);
     }
 
-    public function matchResult(): HasOne
+    public function matchResult(): BelongsTo
     {
-        return $this->hasOne(MatchResult::class);
+        return $this->belongsTo(MatchResult::class);
     }
 }

--- a/app/Policies/MatchResultPolicy.php
+++ b/app/Policies/MatchResultPolicy.php
@@ -6,7 +6,7 @@ use App\Models\MatchResult;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
-class MatchPolicy
+class MatchResultPolicy
 {
     use HandlesAuthorization;
 

--- a/app/Services/StandingService.php
+++ b/app/Services/StandingService.php
@@ -58,11 +58,8 @@ class StandingService
      */
     public function applyMatchResult(MatchResult $match): void
     {
-        /** @var Score[] $scores */
-        $scores = [$match->leftScore, $match->rightScore];
-
-        DB::transaction(function () use ($match, $scores) {
-            foreach ($scores as $score) {
+        DB::transaction(function () use ($match) {
+            foreach ($match->scores as $score) {
                 $standing = $score->entry
                     ->standings()
                     ->whereStageId($match->round->stage_id)

--- a/database/migrations/2024_12_17_194256_create_match_results_table.php
+++ b/database/migrations/2024_12_17_194256_create_match_results_table.php
@@ -11,8 +11,6 @@ return new class extends Migration {
             $table->id();
 
             $table->foreignId('round_id')->constrained('rounds');
-            $table->foreignId('left_score_id')->constrained('scores');
-            $table->foreignId('right_score_id')->constrained('scores');
             $table->foreignId('winner_id')->nullable()->constrained('entries');
 
             $table->dateTime('shot_at')->index();

--- a/database/migrations/2024_12_17_195633_create_scores_table.php
+++ b/database/migrations/2024_12_17_195633_create_scores_table.php
@@ -10,8 +10,10 @@ return new class extends Migration {
         Schema::create('scores', function (Blueprint $table) {
             $table->id();
 
+            $table->foreignId('match_result_id')->constrained('match_results');
             $table->foreignId('entry_id')->constrained('entries');
 
+            $table->string('side', 5)->index();
             $table->unsignedTinyInteger('handicap_before');
             $table->unsignedTinyInteger('handicap_after');
             $table->unsignedMediumInteger('allowance');

--- a/database/seeders/CompetitionSeeder.php
+++ b/database/seeders/CompetitionSeeder.php
@@ -12,9 +12,6 @@ class CompetitionSeeder extends Seeder
 {
     public function run(): void
     {
-        Stage::query()->forceDelete();
-        Competition::query()->forceDelete();
-
         Competition::factory()
             ->count(5)
             ->create()

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,9 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder

--- a/database/seeders/EntrySeeder.php
+++ b/database/seeders/EntrySeeder.php
@@ -11,9 +11,6 @@ class EntrySeeder extends Seeder
 {
     public function run(): void
     {
-        Standing::query()->forceDelete();
-        Entry::query()->forceDelete();
-
         foreach (Competition::all() as $competition) {
             if ($competition->entries()->count() > 0) {
                 continue;

--- a/resources/views/matches/partials/match-form.blade.php
+++ b/resources/views/matches/partials/match-form.blade.php
@@ -37,7 +37,7 @@
                 <div class="mt-1 grid grid-cols-1">
                     <select
                         id="leftEntryId"
-                        name="left_score[entry_id]"
+                        name="scores[left][entry_id]"
                         autocomplete="off"
                         required
                         class="col-start-1 row-start-1 w-full h-[42px] appearance-none bg-none rounded-md bg-white dark:bg-gray-900 py-1.5 pl-3 pr-8 text-base text-gray-900 dark:text-gray-200 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-700 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
@@ -64,7 +64,7 @@
                         />
                     </svg>
                 </div>
-                <x-input-error :messages="$errors->get('left_score.entry_id')" class="mt-2"/>
+                <x-input-error :messages="$errors->get('scores.left.entry_id')" class="mt-2"/>
             </div>
 
             {{--Match Points--}}
@@ -74,14 +74,14 @@
                     type="number"
                     class="block mt-1 w-full"
                     id="leftMatchPoints"
-                    name="left_score[match_points]"
+                    name="scores[left][match_points]"
                     min="0"
                     max="150"
                     autocomplete="off"
                     required
-                    :value="old('left_score.match_points', isset($match)? $match->leftScore->match_points : '')"
+                    :value="old('scores.left.match_points', isset($match)? $match->leftScore->match_points : '')"
                 />
-                <x-input-error :messages="$errors->get('left_score.match_points')" class="mt-2"/>
+                <x-input-error :messages="$errors->get('scores.left.match_points')" class="mt-2"/>
             </div>
         </div>
 
@@ -97,7 +97,7 @@
                 <div class="mt-1 grid grid-cols-1">
                     <select
                         id="rightEntryId"
-                        name="right_score[entry_id]"
+                        name="scores[right][entry_id]"
                         autocomplete="off"
                         required
                         class="col-start-1 row-start-1 w-full h-[42px] appearance-none bg-none rounded-md bg-white dark:bg-gray-900 py-1.5 pl-3 pr-8 text-base text-gray-900 dark:text-gray-200 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-700 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
@@ -124,7 +124,7 @@
                         />
                     </svg>
                 </div>
-                <x-input-error :messages="$errors->get('right_score.entry_id')" class="mt-2"/>
+                <x-input-error :messages="$errors->get('scores.right.entry_id')" class="mt-2"/>
             </div>
 
             {{--Match Points--}}
@@ -134,14 +134,14 @@
                     type="number"
                     class="block mt-1 w-full"
                     id="rightMatchPoints"
-                    name="right_score[match_points]"
+                    name="scores[right][match_points]"
                     min="0"
                     max="150"
                     autocomplete="off"
                     required
-                    :value="old('right_score.match_points', isset($match)? $match->rightScore->match_points : '')"
+                    :value="old('scores.right.match_points', isset($match)? $match->rightScore->match_points : '')"
                 />
-                <x-input-error :messages="$errors->get('right_score.match_points')" class="mt-2"/>
+                <x-input-error :messages="$errors->get('scores.right.match_points')" class="mt-2"/>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This changes the relationship between a MatchResult and a Score, from 2x 1:1 relationships to a single 1:N relationship. Helper methods have been added to MatchResult to make it easy to find the left or right score without having to filter a collection.

Closes #35